### PR TITLE
Fix: Resolve prop warning in MeetupCard template component

### DIFF
--- a/components/MeetupCard.vue
+++ b/components/MeetupCard.vue
@@ -14,13 +14,14 @@
         </div>
         <div class="mt-2">
             <div class="text-grey-700">
-                <component :is="linkTo?'a':'div'" :href="linkTo || ''" class="focus:outline-none">
+                <component
+                    :is="linkTo ? 'a' : 'div'"
+                    :href="linkTo || ''"
+                    class="focus:outline-none"
+                >
                     <!-- Extend touch target to entire panel -->
                     <div class="flex items-center">
-                        <div
-                            class="absolute inset-0"
-                            aria-hidden="true"
-                        ></div>
+                        <div class="absolute inset-0" aria-hidden="true"></div>
                         <div v-if="slack" class="flex items-center">
                             <svg
                                 class="w-5 h-5 mr-2"


### PR DESCRIPTION
### Description
`slack` is marked as required in the `props` definition of `MeetupCard`, but it's [left out by one of the users](https://github.com/devedmonton/devedmonton.com/blob/5c35d9b7ce939af5556f2fe302ba08d5421c79c1/pages/index.vue#L502)—and the conditional logic in the component allows for the prop to be undefined anyhow.

This PR removes the requirement for `slack` and gives it a default of `null`. It also simplifies the conditional rendering logic to cut repetition and make it easier to follow.

### Testing
Viewed side by side with production version (at many browser sizes) to make sure the refactoring resulted in no visible or functional changes.