### PR TITLE
Updates the MeetupCard component so that the links in cards open in new tab instead of the same

### DIFF
--- a/components/MeetupCard.vue
+++ b/components/MeetupCard.vue
@@ -5,6 +5,7 @@
         <component
             :is="linkTo ? 'a' : 'div'"
             :href="linkTo || ''"
+            :target="linkTo ? '_blank' : '_self'"
             class="focus:outline-none"
             :aria-label="name + ' website'"
         >


### PR DESCRIPTION
Updates the Meetup cards to address issue #173. The links now open in a new tab instead of opening in the same tab.