### PR TITLE
Removing the slack from yegwit that was accidentally added years ago

### DIFF
--- a/components/MeetupsSection.vue
+++ b/components/MeetupsSection.vue
@@ -91,7 +91,6 @@ export default {
                     name: "Edmonton Women In Tech",
                     logo: require("../assets/logos/yegwit.png"),
                     linkTo: "https://yegwit.com/",
-                    slack: "#meetup-r",
                     description: ` YEGWIT aims to build a strong and safe group for women,
                         diverse genders, and allies in tech with the goal of
                         fostering engagement and opportunity, providing


### PR DESCRIPTION
They don't have a public slack

## What issue is this referencing?

<!--
Delete what is in this comment tag and reference an issue by typing # and then searching whatever key words

Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

this pr fixes #195 

## Have you run the linting command in the `README.md`?

-   [x ] yes! `npm run lint-check`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x ] yes!

## My node version matches the one suggested when running `nvm use`?

-   [ x] yes!
