### PR TITLE
Made the heading size consistent in all the pages

### DIFF
--- a/pages/become_a_member.vue
+++ b/pages/become_a_member.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="max-w-7xl mx-auto spx-6 px-6 lg:px-8 text-lg">
-        <h1 class="text-2xl font-bold py-4">Become a Member</h1>
+        <h1
+            class="py-4 text-3xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10"
+        >
+            Become a Member
+        </h1>
         <div class="text-gray-500">
             <p class="py-2">
                 Thank you for your interest in becoming a DES member! Firstly we

--- a/pages/board.vue
+++ b/pages/board.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="max-w-7xl mx-auto spx-6 px-6 lg:px-8 text-lg">
-        <h1 class="text-2xl font-bold py-4">Dev Edmonton Society Board</h1>
+        <h1
+            class="py-4 text-3xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10"
+        >
+            Dev Edmonton Society Board
+        </h1>
         <ol>
             <li>
                 <h2 class="text-xl font-bold py-2 border-b border-lightgrey">

--- a/pages/board_recruiting.vue
+++ b/pages/board_recruiting.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="max-w-7xl mx-auto spx-6 px-6 lg:px-8">
-        <h1 class="text-2xl font-bold py-4">Board Recruiting</h1>
+        <h1
+            class="py-4 text-3xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10"
+        >
+            Board Recruiting
+        </h1>
         <p>
             Open positions will advertised in the months preceding the society’s
             Annual General Meeting.

--- a/pages/code_of_conduct.vue
+++ b/pages/code_of_conduct.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="max-w-7xl mx-auto spx-6 px-6 lg:px-8 code-of-coduct">
-        <h1 class="text-2xl font-bold py-4">Code of Conduct</h1>
+        <h1
+            class="py-4 text-3xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10"
+        >
+            Code of Conduct
+        </h1>
         <ol>
             <li>
                 <h2 class="text-xl font-bold py-2 border-b border-lightgrey">

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -5,7 +5,9 @@
                 <input type="hidden" name="form-name" value="contact" />
                 <div>
                     <div>
-                        <h3 class="text-lg leading-6 font-medium text-gray-900">
+                        <h3
+                            class="py-4 text-3xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10"
+                        >
                             Contact Us
                         </h3>
                         <p class="mt-1 text-sm leading-5 text-gray-500">

--- a/pages/sponsors.vue
+++ b/pages/sponsors.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
-        <h1 class="text-2xl font-bold py-4">Sponsors</h1>
+        <h1
+            class="py-4 text-3xl leading-9 tracking-tight font-extrabold text-gray-900 sm:text-4xl sm:leading-10"
+        >
+            Sponsors
+        </h1>
         <div class="cards-grid">
             <SponsorCard>
                 <template #image>


### PR DESCRIPTION
## What issue is this referencing?
Make the heading size consistent in all the pages #202


Modified the Heading by adding tailwind css to make in consistent across the website in the below Pages 

- become_a_member
- board_recruiting
- board
- code_of_conduct
- contact
- sponsors.