### PR TITLE
fix: letting the ExternalInfoCard responsive again

### DIFF
--- a/components/ExternalInfoCard.vue
+++ b/components/ExternalInfoCard.vue
@@ -15,7 +15,9 @@
             </div>
         </component>
         <div class="flex items-center mb-2">
-            <div class="flex items-center lg:items-center lg:flex-row sm:flex-col sm:items-start">
+            <div
+                class="flex items-center lg:items-center lg:flex-row sm:flex-col sm:items-start"
+            >
                 <img
                     v-if="logo"
                     :class="`h-12 mr-6 rounded-md inline-flex p-1 object-contain ${

--- a/components/ExternalInfoCard.vue
+++ b/components/ExternalInfoCard.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="relative group bg-white p-6 focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
+        class="relative p-6 bg-white group focus-within:ring-2 focus-within:ring-inset focus-within:ring-indigo-500"
     >
         <component
             :is="linkTo ? 'a' : 'div'"
@@ -15,22 +15,24 @@
             </div>
         </component>
         <div class="flex items-center mb-2">
-            <img
-                v-if="logo"
-                :class="`h-12 mr-6 rounded-md inline-flex p-1 object-contain ${
-                    logoBg ? logoBg : null
-                }`"
-                :src="logo"
-                :alt="`${name}-logo`"
-            />
-            <h3 class="text-xl font-medium pr-8">{{ name }}</h3>
+            <div class="flex items-center lg:items-center lg:flex-row sm:flex-col sm:items-start">
+                <img
+                    v-if="logo"
+                    :class="`h-12 mr-6 rounded-md inline-flex p-1 object-contain ${
+                        logoBg ? logoBg : null
+                    }`"
+                    :src="logo"
+                    :alt="`${name}-logo`"
+                />
+                <h3 class="pr-8 text-xl font-medium">{{ name }}</h3>
+            </div>
             <span
                 v-if="linkTo"
-                class="pointer-events-none absolute top-4 right-4 text-gray-300 group-hover:text-brand-primary"
+                class="absolute text-gray-300 pointer-events-none top-4 right-4 group-hover:text-brand-primary"
                 aria-hidden="true"
             >
                 <svg
-                    class="h-6 w-6"
+                    class="w-6 h-6"
                     xmlns="http://www.w3.org/2000/svg"
                     fill="currentColor"
                     viewBox="0 0 24 24"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "start": "nuxt start",
     "generate": "npm run test && nuxt generate",
     "test": "npm run lint-check",
-    "lint-check": "eslint {components,layouts,pages}/**/*.vue",
-    "lint-fix": "eslint {components,layouts,pages}/**/*.vue --fix"
+    "lint-check": "eslint '{components,layouts,pages}/**/*.vue'",
+    "lint-fix": "eslint '{components,layouts,pages}/**/*.vue' --fix"
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.22.10",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "start": "nuxt start",
     "generate": "npm run test && nuxt generate",
     "test": "npm run lint-check",
-    "lint-check": "eslint '{components,layouts,pages}/**/*.vue'",
-    "lint-fix": "eslint '{components,layouts,pages}/**/*.vue' --fix"
+    "lint-check": "eslint {components,layouts,pages}/**/*.vue",
+    "lint-fix": "eslint {components,layouts,pages}/**/*.vue --fix"
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.22.10",


### PR DESCRIPTION
## What issue is this referencing?

This PR addresses issue #209 regarding the responsiveness of the ExternalInfoCard component. Previously, the name used within this component was exceeding the component's limits.

What I've done is as follows: For smaller screens, I've adjusted the header behavior of the component by setting the flex-direction to column. This places the image above the name, preventing longer names from exceeding the component's boundaries.

## Have you run the linting command in the `README.md`?

-   [x] yes! `npm run lint-check`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
