### PR TITLE
Add pr-checks script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,11 +6,9 @@ Delete what is in this comment tag and reference an issue by typing # and then s
 Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
 -->
 
-## Do the following commands from the `README.md` run without warnings or errors?
+## Does the following command run without warnings or errors?
 
--   [ ] yes! `npm run test-run`
--   [ ] yes! `npm run lint-check`
--   [ ] yes! `npm run format-check`
+-   [ ] yes! `npm run pr-checks`
 
 ## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write .",
     "format-check": "prettier --check .",
     "lint-check": "eslint . --ext .js,.vue",
-    "lint-fix": "eslint . --ext .js,.vue --fix"
+    "lint-fix": "eslint . --ext .js,.vue --fix",
+    "pr-checks": "npm run lint-check && npm run format-check && npm run test-run"
   },
   "dependencies": {
     "@babel/eslint-parser": "^7.22.10",


### PR DESCRIPTION
## What issue is this referencing?

Realised when using it that it's a little cumbersome to have contributors run 3 scripts on the PR template so added a script to run them all `npm run pr-checks`

## Do the following commands from the `README.md` run without warnings or errors?

-   [x] yes! `npm run test-run`
-   [x] yes! `npm run lint-check`
-   [x] yes! `npm run format-check`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
