### PR TITLE
Fix (#369): Remove Canada Learning code from the site

### DIFF
--- a/constants/events.ts
+++ b/constants/events.ts
@@ -6,12 +6,6 @@ export const events = [
     description: 'Google Developer Groups has an Edmonton chapter! Their vision is to foster an engaging and inclusive developer\'s community. A place where you can meet your fellow developers, career mentors, and boost your technical skills. Whether you are an advanced developer, or you just start to pivot your way in the tech industry, we welcome you to the community. They mostly focus on Google Technologies, such as Google Cloud Computing, Firebase, Flutter, Android, Machine Learning, and Earth Engine.',
   },
   {
-    name: 'Canada Learning Code',
-    image: '/events/clc.png',
-    to: 'https://www.canadalearningcode.ca/chapters/edmonton',
-    description: 'Canada Learning Code designs, delivers, and partners on technology education for people in Canada. They have workshops for kids, teens, girls, and adults. They are always looking for mentors, teachers and coordinators.',
-  },
-  {
     name: 'Rainforest Alberta',
     image: '/events/rac.png',
     to: 'https://www.rainforestab.ca/edmonton.html',


### PR DESCRIPTION
**Description**  
This pull request addresses and resolves issue #369 by removing the **"Canada Learning Code"** component from the site.

### Changes Made
- **Code Removal**  
  Deleted all references to **"Canada Learning Code"** in the `events.ts` file within the `constans` folder.

### Checklist
- [x] Confirmed that the code removal does not affect other functionalities.

**Thank you!**


![Screenshot 2024-09-27 185133](https://github.com/user-attachments/assets/0b78c3f3-e6e3-40da-978d-2dc071d1a2f4)
