### PR TITLE
Fix(#368): Rearranging Header

### DIFF
--- a/components/app/Footer.vue
+++ b/components/app/Footer.vue
@@ -7,10 +7,7 @@ const { data: navigation } = await useAsyncData('navigation:footer', () => fetch
 </script>
 
 <template>
-  <footer
-    id="footer"
-    class="container mx-auto"
-  >
+  <footer id="footer" class="container mx-auto">
     <div class="w-full max-w-screen-xl mx-auto border-t border-neutral-400/20">
       <div class="flex md:flex-row flex-col gap-8 items-center justify-between py-4">
         <NuxtLink
@@ -18,17 +15,10 @@ const { data: navigation } = await useAsyncData('navigation:footer', () => fetch
           to="/"
           class="flex justify-center md:order-1 order-2"
         >
-          <AppLogo
-            :scrolling="true"
-            class="h-12"
-          />
+          <AppLogo :scrolling="true" class="h-12" />
         </NuxtLink>
         <ul class="flex flex-wrap justify-center gap-4 items-center text-sm font-medium text-gray-600 dark:text-gray-400 md:mx-0 mx-2 order-1">
-          <li
-            v-for="item of navigation"
-            :key="item.title"
-            class="mb-4"
-          >
+          <li v-for="item of navigation" :key="item.title" class="mb-4">
             <NuxtLink
               :title="item.title"
               :to="item._path"
@@ -37,6 +27,9 @@ const { data: navigation } = await useAsyncData('navigation:footer', () => fetch
             >
               {{ item.title }}
             </NuxtLink>
+          </li>
+          <li class="mb-4">
+            <NuxtLink to="/contact" exact-active-class="text-primary dark:text-secondary bg-gray-400/20" class="hover:underline py-1.5 px-4 rounded-lg">Contact</NuxtLink>
           </li>
         </ul>
       </div>

--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -22,8 +22,8 @@ export const navigation: NavItem[] = [
     to: '/resources',
   },
   {
-    name: 'Contact',
-    icon: 'i-ph-phone-duotone',
-    to: '/contact',
+    name: 'Companies', // Changed from 'Contact' to 'Companies'
+    icon: 'i-ph-building', // Choose an appropriate icon for companies
+    to: '/companies', // Link to the new companies page
   },
 ]

--- a/pages/companies.vue
+++ b/pages/companies.vue
@@ -1,0 +1,26 @@
+<template>
+  <main>
+    <AppSection :group="companyGroup" />
+  </main>
+</template>
+
+<script setup lang="ts">
+import { companies } from '@/constants/companies'; // Adjust the path as necessary
+
+// Alphabetically sort companies
+const sortedCompanies = companies.sort((a, b) => a.name.localeCompare(b.name));
+
+const companyGroup = { name: 'Edmonton Companies', items: sortedCompanies };
+
+const title = 'Edmonton Companies';
+const description = 'A list of Edmonton companies to help the Dev Edmonton community.';
+
+useServerSeoMeta({
+  title,
+  description,
+});
+</script>
+
+<style scoped>
+/* Add any styles you want for this page, if necessary */
+</style>

--- a/pages/resources.vue
+++ b/pages/resources.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 const group = { name: 'Community Resources', items: resources }
-const companyGroup = { name: 'Edmonton Companies', items: companies }
 
 const title = 'Resources'
 const description = 'Lists of all the resources that we know of to help the Dev Edmonton community.'
@@ -19,6 +18,5 @@ defineOgImage({
 <template>
   <main>
     <AppSection :group="group" />
-    <AppSection :group="companyGroup" />
   </main>
 </template>


### PR DESCRIPTION

### *Description*
This pull request addresses issue *#368* by reorganizing the header and footer sections of our website.

### *Changes Made*
1. **Header Update**:
   - Removed the *Contacts* section from the header.
   - Replaced it with a new *Companies* section that links to the dedicated page.

2. **Footer Update**:
   - Added the *Contact* section back into the footer for easy access.

3. **Company Page**:
   - Created a dedicated page for the list of companies, sorted alphabetically.

### *Checklist*
- [x] Confirmed that the *Companies* section appears in the header.
- [x] Ensured that the *Contact* information is accessible in the footer.
- [x] Verified that the company list is alphabetized and displays correctly.
![Screenshot 2024-09-27 213148](https://github.com/user-attachments/assets/53bf4bb7-271d-4b81-91ba-1ae71808a903)
![Screenshot 2024-09-27 213211](https://github.com/user-attachments/assets/460817aa-5031-4542-bfa3-ac843019952c)
