### PR TITLE
(fix #370)Added Edmnton Wordpress meetup to the list of meetups

### DIFF
--- a/constants/meetups.ts
+++ b/constants/meetups.ts
@@ -79,4 +79,10 @@ Ready to level up? See you at Leetcode Night!A combination of the YEGRB, Exchang
     to: 'https://hacked.compeclub.com/',
     description: 'One of Alberta\'s Largest Student Run Hackathons. HackED is the premiere annual 24-hour hackathon from the Computer Engineering Club of the University of Alberta.',
   },
+   {
+    name: 'Edmonton WordPress Meetup',
+    image: '/meetups/wordpress.png',
+    to: 'https://www.linkedin.com/groups/14490539/',
+    description: 'The Edmonton WordPress Meetup is open to anyone and everyone locally who is interested in WordPress, the leading web publishing and open-source software platform. ',
+  },
 ]

--- a/constants/meetups.ts
+++ b/constants/meetups.ts
@@ -79,7 +79,7 @@ Ready to level up? See you at Leetcode Night!A combination of the YEGRB, Exchang
     to: 'https://hacked.compeclub.com/',
     description: 'One of Alberta\'s Largest Student Run Hackathons. HackED is the premiere annual 24-hour hackathon from the Computer Engineering Club of the University of Alberta.',
   },
-   {
+  {
     name: 'Edmonton WordPress Meetup',
     image: '/meetups/wordpress.png',
     to: 'https://www.linkedin.com/groups/14490539/',


### PR DESCRIPTION
What issue is this referencing?
This PR is referencing https://github.com/devedmonton/DES-Website/issues/370, which adds WordPress to the list of meetups.

Do these code changes work locally and have you tested that they fix the issue yourself?
yes!
Does the following command run without warnings or errors?
yes! npm run pr-checks
Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?
yes!
My node version matches the one suggested when running nvm use?
yes!