### PR TITLE
Change default calendar week start from Monday to Sunday for better readability

### DIFF
--- a/components/app/Calendar.vue
+++ b/components/app/Calendar.vue
@@ -35,7 +35,7 @@ const onEventClick = (event: any, e: any) => {
       :events-on-month-view="true"
       :twelve-hour="true"
       :events="group.items"
-      :start-week-on-sunday="false"
+      :start-week-on-sunday="true"
       :disable-views="['years', 'year', 'day']"
       :time-from="8 * 60"
       :time-to="22 * 60"


### PR DESCRIPTION
The `start-week-on-sunday bug` has been resolved and now functions correctly! https://github.com/antoniandre/vue-cal-v4/pull/528 

I hope this change will help improve the readability of the calendar.

## What issue is this referencing?
#421

<!--
Reference an issue by typing # (outside of this comment) and then searching whatever key words

Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
