### PR TITLE
Rearrange header and created companies page.

### DIFF
--- a/constants/navigation.ts
+++ b/constants/navigation.ts
@@ -22,8 +22,8 @@ export const navigation: NavItem[] = [
     to: '/resources',
   },
   {
-    name: 'Contact',
-    icon: 'i-ph-phone-duotone',
-    to: '/contact',
+    name: 'Companies',
+    icon: 'i-ph-building-duotone',
+    to: '/companies',
   },
 ]

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,0 +1,7 @@
+---
+title: Contact
+footer: true
+sitemap:
+  loc: /contact
+  lastmod: 2024-10-18
+---

--- a/pages/companies.vue
+++ b/pages/companies.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-const group = { name: 'Community Resources', items: resources }
+const group = { name: 'Edmonton Companies', items: companies.sort((a, b) => a.name.localeCompare(b.name)) }
 
-const title = 'Resources'
-const description = 'Lists of all the resources that we know of to help the Dev Edmonton community.'
+const title = 'companies'
+const description = 'Lists of all the companies who are part of the Dev Edmonton community.'
 
 useServerSeoMeta({
   title,


### PR DESCRIPTION
Resources has been divided so that companies is now its own separate page. Contact navlink was removed from the header and added to the footer. New companies page has a navlink added to the header. Companies on the companies page are now alphabetized by name.

## What issue is this referencing?
#368

<!--
Reference an issue by typing # (outside of this comment) and then searching whatever key words

Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!

## Screenshots:

### Header + List of companies (now alphabetized):
<img width="957" alt="Screenshot 2024-10-18 210643" src="https://github.com/user-attachments/assets/57328983-1f5f-4efd-b95a-964152d35548">

### Footer:
![Screenshot 2024-10-18 210702](https://github.com/user-attachments/assets/d5a02f28-69ea-4b31-aef7-05f8ca52e078)

