### PR TITLE
Events end date and time fix.

### DIFF
--- a/pages/events.vue
+++ b/pages/events.vue
@@ -35,8 +35,8 @@ function renderMarkdown(description: string) {
 
 const createEventsList = (events: any) => {
   return events.map((event: any) => new Event(
-    event.start.dateTime || event.start.date,
-    event.end.dateTime || event.end.date,
+    (event.start.dateTime || `${event.start.date}T00:00:00`),
+    (event.end.dateTime || `${event.end.date}T23:59:59`),
     event.summary,
     '',
     '',


### PR DESCRIPTION
## What issue is this referencing?
This PR further improves and fixes #418
<!--
Reference an issue by typing # (outside of this comment) and then searching whatever key words

Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!

# What happened
Events that don't have a time use the date field instead of the dateTime field. Originally these weren't showing up on the calendar and it was fixed by using an OR to check for the usage of date field. This worked to make them appear but it create more issues such as start and end time being defaulted and equal to each other. And the end date wasn't correct. 

These new changes forcibly add a time onto the date time. Those two issues are now fixed. Future changes could potentially be made to just hide the time for events that are all day or don't have a start and end time but this remove a lot of weirdness and the bugs with the calendar.

## Screenshots

You can see in this screenshot that the end date for DevelopEd Hackathon is now correctly on the 11th.
![Screenshot 2024-10-23 124707](https://github.com/user-attachments/assets/f8515c72-d36a-4e6c-8a4e-695b3a5f2b3b)

The start date and end date now stretch the full day.
![Screenshot 2024-10-23 124733](https://github.com/user-attachments/assets/bf3c8d36-0a27-49aa-abb7-78fe34821220)
