### PR TITLE
Auto Event importing from Meetup Sources through single server endpoint. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "google-auth-library": "^9.14.2",
         "googleapis": "^144.0.0",
         "happy-dom": "^15.7.4",
+        "ical.js": "^2.1.0",
+        "node-fetch": "^3.3.2",
         "nuxt": "^3.13.2",
         "swiper": "^11.1.4",
         "tailwind-merge": "^2.5.4",
@@ -3416,6 +3418,26 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/@netlify/functions": {
@@ -9250,6 +9272,15 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -9826,17 +9857,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/encoding-sniffer": {
@@ -10799,6 +10819,29 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
@@ -10970,6 +11013,18 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -11170,6 +11225,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/gcp-metadata": {
@@ -12011,6 +12086,12 @@
       "engines": {
         "node": ">=16.17.0"
       }
+    },
+    "node_modules/ical.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.1.0.tgz",
+      "integrity": "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ==",
+      "dev": true
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -14956,6 +15037,25 @@
         "node": "^16 || ^18 || >= 20"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
@@ -14972,23 +15072,21 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dev": true,
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-fetch-native": {
@@ -22127,6 +22225,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "google-auth-library": "^9.14.2",
     "googleapis": "^144.0.0",
     "happy-dom": "^15.7.4",
+    "ical.js": "^2.1.0",
+    "node-fetch": "^3.3.2",
     "nuxt": "^3.13.2",
     "swiper": "^11.1.4",
     "tailwind-merge": "^2.5.4",

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -1,5 +1,4 @@
-import { google } from 'googleapis'
-import { JWT } from 'google-auth-library'
+import { getEvents } from '../utils/calendar'
 
 /*
 Reference for folks who maybe curious.
@@ -10,69 +9,6 @@ Reference for folks who maybe curious.
 - The google calendar user needs to give the "Make Changes to Events" permissions to the service account
   - Refer to here https://dev.to/pedrohase/create-google-calender-events-using-the-google-api-and-service-accounts-in-nodejs-22m8
 */
-
-/**
- * Retrieves events from Google Calendar.
- * @async
- * @param {Object} options - The options object.
- * @param {string} options.googleCalendarId - The ID of the Google Calendar should be an email.
- * @param {Object} options.serviceAccountCredentials - The service account credentials for google authentication.
- * @param {Date} options.startDate - The start date from which to retrieve events.
- * @param {number} options.limitEvents - The maximum number of events to retrieve.
- * @returns {Promise<Array>} An array of events.
- */
-export const getEvents = async ({
-  googleCalendarId,
-  serviceAccountCredentials,
-  startDate,
-  limitEvents,
-}) => {
-  if (!startDate) {
-    startDate = new Date().toISOString()
-  }
-  else {
-    startDate = new Date(startDate).toISOString()
-  }
-
-  if (!limitEvents) {
-    limitEvents = 10
-  }
-
-  // get the credentials from the service account
-  const client = new JWT({
-    email: serviceAccountCredentials.client_email,
-    key: serviceAccountCredentials.private_key,
-    scopes: [ // set the right scope
-      'https://www.googleapis.com/auth/calendar',
-      'https://www.googleapis.com/auth/calendar.events',
-    ],
-  })
-
-  // get the calendar api using google
-  const calendar = google.calendar({ version: 'v3' })
-  // get the events from the calendar
-  const resposnse = await calendar.events.list({
-    auth: client,
-    calendarId: googleCalendarId,
-    timeMin: startDate,
-    maxResults: limitEvents,
-    singleEvents: true,
-    orderBy: 'startTime',
-  })
-
-  // return the events.
-  return resposnse.data.items
-}
-/**
- * API endpoint for fetching events for DES.
- * @param {Object} event - The event object.
- * @param {string} startDate - Start date of the events you want to fetch (query param).
- * @param {number} limitEvents - Limit the number of events to fetch (query param)
- * @example
- * // Example usage:
- * // GET /api/events?startDate=2024-05-01&limitEvents=25
- * // GET /api/events
- */
 
 export default defineEventHandler(async (event) => {
   // get the query params

--- a/server/api/events.js
+++ b/server/api/events.js
@@ -21,7 +21,7 @@ Reference for folks who maybe curious.
  * @param {number} options.limitEvents - The maximum number of events to retrieve.
  * @returns {Promise<Array>} An array of events.
  */
-const getEvents = async ({
+export const getEvents = async ({
   googleCalendarId,
   serviceAccountCredentials,
   startDate,

--- a/server/api/import_events.js
+++ b/server/api/import_events.js
@@ -186,7 +186,7 @@ const createAllEvents = async ({
   try {
     // Map each event to a calendar.events.insert call
     const insertCalendarPromises = newEvents.map((event) => {
-      calendar.events.insert({
+      return calendar.events.insert({
         auth: client,
         calendarId: googleCalendarId,
         resource: event,
@@ -194,8 +194,8 @@ const createAllEvents = async ({
     })
     // log the created events
     const responses = await Promise.all(insertCalendarPromises)
-    responses.forEach((response) => {
-      console.log(`Event created:`, response.data.htmlLink)
+    responses.forEach(() => {
+      console.log(`Event created Successfully!`)
     })
   }
   catch (error) {

--- a/server/api/import_events.js
+++ b/server/api/import_events.js
@@ -32,6 +32,7 @@ const ICAL_URLS = [
   'http://api.lu.ma/ics/get?entity=calendar&id=cal-N0bfLPnGQ1LC86P', // Leetnight
   'https://www.meetup.com/Edmonton-NET-User-Group/events/ical/', // .NET user group
   'https://www.meetup.com/flutter-edmonton/events/ical/', // flutter edmonton
+  'https://www.meetup.com/edmonton-wordpress-meetup-group/events/ical/', // wordpress meetup
 ]
 
 // gets the ICAL from the urls above.

--- a/server/api/import_events.js
+++ b/server/api/import_events.js
@@ -1,0 +1,253 @@
+import fetch from 'node-fetch'
+import ICAL from 'ical.js'
+
+import { google } from 'googleapis'
+import { JWT } from 'google-auth-library'
+
+import { getEvents } from './events'
+
+/*
+A short explanation about this gargantuan file/function.
+Essentially this just pulls some icals from the calendars in meetup in the
+ICAL_URLS link and
+(say here https://www.meetup.com/edmontonunlimited/events/ under "events" click
+"Calendar" and there's a "ical" link next to "Subscribe to a feed of this calendar:")
+
+The function "importAndProcessExternalEvents" is the important one here
+look pretty far at the bottom and goes through 4 steps.
+  Step: 1 Import the events from meetup
+  Step: 2: Get all of the Events in the GMAIL Calendar
+  Step: 3: Identify new Events (that aren't already in the calendar)
+  Step: 4: Create the new Events in gmail (doesn't make duplicates)
+
+It just returns ONLY THE NEWLY created events which I thought made sense here.
+
+I'll add this to a nuxt cron here so that we can pull these nightly.
+https://github.com/hywax/nuxt-cron
+*/
+
+const ICAL_URLS = [
+  'https://www.meetup.com/edmontonunlimited/events/ical/', // Edmonton unlimited
+  'https://www.meetup.com/GDG-Cloud-Edmonton/events/ical/', // GDG cloud
+  'http://api.lu.ma/ics/get?entity=calendar&id=cal-N0bfLPnGQ1LC86P', // Leetnight
+  'https://www.meetup.com/Edmonton-NET-User-Group/events/ical/', // .NET user group
+  'https://www.meetup.com/flutter-edmonton/events/ical/', // flutter edmonton
+]
+
+// gets the ICAL from the urls above.
+const fetchICALFromURL = async (url) => {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Node.js Fetch)',
+    },
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ICS file: ${response.statusText}`)
+  }
+  return response.text()
+}
+
+// converts the ICAL data to google calendar events.
+const parseICALData = (icalContent) => {
+  const icalData = ICAL.parse(icalContent) // Parse the ICAL content into jCal format
+  const component = new ICAL.Component(icalData) // Create an ICAL.Component
+  const events = component.getAllSubcomponents('vevent') // Get all VEVENT components
+
+  // Map VEVENT components to Google Calendar API event objects
+  return events.map((event) => {
+    const vevent = new ICAL.Event(event)
+
+    // put this in the format of a google calendar event.
+    return {
+      summary: vevent.summary || 'No Title',
+      description: vevent.description || '',
+      location: vevent.location || '',
+      start: {
+        dateTime: vevent.startDate.toJSDate().toISOString(),
+        timeZone: 'UTC', // Adjust as necessary
+      },
+      end: {
+        dateTime: vevent.endDate.toJSDate().toISOString(),
+        timeZone: 'UTC', // Adjust as necessary
+      },
+    }
+  })
+}
+
+// gets all of the external events from all ICAL sources and combines
+// into one large list.
+const getAllExternalEvents = async () => {
+  console.log('parsing ics')
+  let allExternalEvents = []
+  for (let url of ICAL_URLS) {
+    console.log(`importing from ${url}...`)
+    try {
+      let icsText = await fetchICALFromURL(url)
+      let data = parseICALData(icsText)
+      // add all of the events
+      allExternalEvents = [...data, ...allExternalEvents]
+      console.log('importing successful')
+      console.log('-------------------')
+    }
+    catch (error) {
+      console.log(`error while importing ${url}... skipping...`)
+      console.log(error)
+    }
+  }
+  return allExternalEvents
+}
+
+// gets the existing events from the calendar here.
+const getExistingEvents = async (event) => {
+  const { googleCalendarId, serviceAccountCredentialsJSON } = useRuntimeConfig(event).googleCalendarAPI
+  let serviceAccountCredentials = {}
+  // try to parse the service account credentials or throw an error.
+  try {
+    serviceAccountCredentials = JSON.parse(serviceAccountCredentialsJSON)
+  }
+  catch {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Bad Request',
+      message: 'No Service Account Credentials Provided',
+      error: 'Service Account Credentials are not provided',
+    })
+  }
+  // try parse the events or throw an error
+  try {
+    console.log('Importing internal events from Devedmonton gmail calendar')
+    const events = await getEvents({
+      googleCalendarId,
+      serviceAccountCredentials,
+      limitEvents: 100,
+    })
+    // return the events
+    return events
+  }
+  catch {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Bad Request',
+      message: 'Error Fetching Events',
+      error: 'Could not fetch events',
+    })
+  }
+}
+
+const compareAndGetNewEvents = (existingGmailEvents, importedEvents) => {
+  // check if the importedEvents are in the newEvents
+  const newEvents = importedEvents.filter((importedEvent) => {
+    // check if the event is already in there
+    // check with the title and the start date (I'm assuming there won't be two the same)
+    const importedEventDateOnly = new Date(importedEvent.start.dateTime).toISOString().split('T')[0]
+    return !existingGmailEvents.some((existingEvent) => {
+      const existingDateOnly = new Date(existingEvent.start.dateTime).toISOString().split('T')[0]
+      return (
+        importedEvent.summary.trim() === existingEvent.summary.trim() // summary is title for gmail
+        && importedEventDateOnly === existingDateOnly
+      )
+    })
+  })
+
+  return newEvents
+}
+
+/*
+  Note: there's a bit of duplication here from the "getEvents code"
+  this is a great opportunity for a refactor and a contribution but
+  in full transparency I just want to get this working.
+*/
+const createAllEvents = async ({
+  googleCalendarId,
+  serviceAccountCredentials,
+  newEvents,
+}) => {
+  // get the credentials from the service account
+  const client = new JWT({
+    email: serviceAccountCredentials.client_email,
+    key: serviceAccountCredentials.private_key,
+    scopes: [ // set the right scope
+      'https://www.googleapis.com/auth/calendar',
+      'https://www.googleapis.com/auth/calendar.events',
+    ],
+  })
+  // get the calendar api using google
+  const calendar = google.calendar({ version: 'v3' })// get the credentials from the service account
+
+  try {
+    // Map each event to a calendar.events.insert call
+    const insertCalendarPromises = newEvents.map((event) => {
+      calendar.events.insert({
+        auth: client,
+        calendarId: googleCalendarId,
+        resource: event,
+      })
+    })
+    // log the created events
+    const responses = await Promise.all(insertCalendarPromises)
+    responses.forEach((response) => {
+      console.log(`Event created:`, response.data.htmlLink)
+    })
+  }
+  catch (error) {
+    console.error('Error creating events:', error.message)
+  }
+}
+
+const importAndProcessExternalEvents = async (event) => {
+  // Step: 1 Import the events from meetup
+  let importedEvents = await getAllExternalEvents()
+  // Step: 2: Get all of the Events in the GMAIL Calendar
+  const existingEvents = await getExistingEvents(event)
+  // Step: 3: Identify New Events
+  let newEvents = compareAndGetNewEvents(
+    existingEvents,
+    importedEvents,
+  )
+  // Step: 4: Create the new Events in gmail
+  // Step: 4.1 get the credentials from the service account
+  const { googleCalendarId, serviceAccountCredentialsJSON } = useRuntimeConfig(event).googleCalendarAPI
+  let serviceAccountCredentials
+  try {
+    serviceAccountCredentials = JSON.parse(serviceAccountCredentialsJSON)
+  }
+  catch {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Bad Request',
+      message: 'No Service Account Credentials Provided',
+      error: 'Service Account Credentials are not provided',
+    })
+  }
+  // Step 4.2 create all of them events.
+  try {
+    await createAllEvents({
+      googleCalendarId,
+      serviceAccountCredentials,
+      newEvents,
+    })
+  }
+  catch (error) {
+    console.log(error)
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Bad Request',
+      message: 'Error while creating events',
+      error: 'Google calendar api error.',
+    })
+  }
+
+  // return the new events
+  return newEvents
+}
+
+// this is the api.
+export default defineEventHandler(async (event) => {
+  const newEvents = await importAndProcessExternalEvents(event)
+  return {
+    statusCode: 200,
+    statusMessage: 'Success',
+    message: 'Events imported successfully, new Events added below',
+    events: newEvents,
+  }
+})

--- a/server/utils/calendar.js
+++ b/server/utils/calendar.js
@@ -1,0 +1,122 @@
+import { google } from 'googleapis'
+import { JWT } from 'google-auth-library'
+
+export class ImportCalendarException extends Error {
+  constructor({ message, error }) {
+    super(message) // Call the parent class constructor
+    this.message = message
+    this.error = error
+    this.timestamp = new Date() // Add custom properties if needed
+  }
+}
+
+/**
+ * Creates an authenticated JWT client for accessing Google APIs.
+ *
+ * @function createAuthClient
+ * @param {Object} serviceAccountCredentials - The service account credentials used for authentication.
+ * @param {string} serviceAccountCredentials.client_email - The client email associated with the service account.
+ * @param {string} serviceAccountCredentials.private_key - The private key associated with the service account.
+ * @returns {JWT} - A JWT client authenticated with the provided credentials and configured with the necessary scopes.
+ */
+const createAuthClient = (serviceAccountCredentials) => {
+  const client = new JWT({
+    email: serviceAccountCredentials.client_email,
+    key: serviceAccountCredentials.private_key,
+    scopes: [ // set the right scope
+      'https://www.googleapis.com/auth/calendar',
+      'https://www.googleapis.com/auth/calendar.events',
+    ],
+  })
+  return client
+}
+
+/**
+ * Retrieves events from Google Calendar.
+ * @async
+ * @param {Object} options - The options object.
+ * @param {string} options.googleCalendarId - The ID of the Google Calendar should be an email.
+ * @param {Object} options.serviceAccountCredentials - The service account credentials for google authentication.
+ * @param {Date} options.startDate - The start date from which to retrieve events.
+ * @param {number} options.limitEvents - The maximum number of events to retrieve.
+ * @returns {Promise<Array>} An array of events.
+ */
+export const getEvents = async ({
+  googleCalendarId,
+  serviceAccountCredentials,
+  startDate,
+  limitEvents,
+}) => {
+  if (!startDate) {
+    startDate = new Date().toISOString()
+  }
+  else {
+    startDate = new Date(startDate).toISOString()
+  }
+
+  if (!limitEvents) {
+    limitEvents = 10
+  }
+
+  // get the credentials from the service account
+  const client = createAuthClient(serviceAccountCredentials)
+
+  // get the calendar api using google
+  const calendar = google.calendar({ version: 'v3' })
+  // get the events from the calendar
+  const resposnse = await calendar.events.list({
+    auth: client,
+    calendarId: googleCalendarId,
+    timeMin: startDate,
+    maxResults: limitEvents,
+    singleEvents: true,
+    orderBy: 'startTime',
+  })
+
+  // return the events.
+  return resposnse.data.items
+}
+/**
+ * Creates new events in the Google Calendar.
+ * @async
+ * @param {Object} options - The options object.
+ * @param {string} options.googleCalendarId - The ID of the Google Calendar should be an email.
+ * @param {Object} options.serviceAccountCredentials - The service account credentials for google authentication.
+ * @param {Array<Object>} newEvents - The new events to be created.
+ * @throws {ImportCalendarException} - Thrown if there is an error while creating events in the Google Calendar.
+ * @returns {Promise<void>} - Resolves when all are created.
+ */
+export const createAllEvents = async ({
+  googleCalendarId,
+  serviceAccountCredentials,
+  newEvents,
+}) => {
+  // get the credentials from the service account
+  const client = createAuthClient(serviceAccountCredentials)
+
+  // // get the calendar api using google
+  const calendar = google.calendar({ version: 'v3' })// get the credentials from the service account
+
+  try {
+    // Map each event to a calendar.events.insert call
+    const insertCalendarPromises = newEvents.map((event) => {
+      return calendar.events.insert({
+        auth: client,
+        calendarId: googleCalendarId,
+        resource: event,
+      })
+    })
+    // log the created events
+    const responses = await Promise.all(insertCalendarPromises)
+    responses.forEach(() => {
+      console.log(`Event created Successfully!`)
+    })
+  }
+  catch (error) {
+    console.error('Error creating events:', error.message)
+    throw new ImportCalendarException({
+      message: 'Error creating events in Gmail',
+      error: 'A gmail API error has occurred.',
+    })
+  }
+}


### PR DESCRIPTION
## What issue is this referencing?

Essentially importing events has been a bit of pain into this calendar (which was to be expected). 

This essentially looks at a variety of ical links and downloads them and uploads them to the gmail calendar.

I like this solution because we can continue to add events directly to the gmail in addition to these ical sources, for example [hacked](https://hacked.compeclub.com/) and any eventbrite links [read democamp](https://www.eventbrite.ca/o/democamp-edmonton-56126644423) but reduces a lot of logistics in updating the calendar.

#394 Improving the calendar.
#366 (kind of because we might not need it)

Functionality demonstrated in a gif below (it's a little big so I shared it from my drive).
[You'll have to download it](https://drive.google.com/file/d/1zTY6Msbtn0S_ezVPYGaLktrVVPMYJStL/view?usp=sharing)

I'd like to add this to a cron job so it imports every night, I think we can do this fairly easily with [nuxt-cron](https://github.com/hywax/nuxt-cron)

## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
