### PR TITLE
DRAFT: Moved ImportCalendarException to import_events to fix weird unimport error.

### DIFF
--- a/server/api/import_events.js
+++ b/server/api/import_events.js
@@ -1,8 +1,16 @@
 import fetch from 'node-fetch'
 import ICAL from 'ical.js'
 
-import { ImportCalendarException, getEvents, createAllEvents } from '../utils/calendar'
+import { getEvents, createAllEvents } from '../utils/calendar'
 
+class ImportCalendarException extends Error {
+  constructor({ message, error }) {
+    super(message) // Call the parent class constructor
+    this.message = message
+    this.error = error
+    this.timestamp = new Date() // Add custom properties if needed
+  }
+}
 /*
 A short explanation about this gargantuan file/function.
 Essentially this just pulls some icals from the calendars in meetup in the
@@ -168,7 +176,7 @@ export const importAndProcessExternalEvents = async ({ googleCalendarId, service
     })
   }
   catch {
-    throw ImportCalendarException({
+    throw new ImportCalendarException({
       message: 'Error while creating events',
       error: 'Google calendar api error.',
     })
@@ -187,7 +195,7 @@ export default defineEventHandler(async (event) => {
     serviceAccountCredentials = JSON.parse(serviceAccountCredentialsJSON)
   }
   catch {
-    throw ImportCalendarException({
+    throw new ImportCalendarException({
       message: 'No Service Account Credentials Provided',
       error: 'Service Account Credentials are not provided',
     })

--- a/server/utils/calendar.js
+++ b/server/utils/calendar.js
@@ -1,15 +1,6 @@
 import { google } from 'googleapis'
 import { JWT } from 'google-auth-library'
 
-export class ImportCalendarException extends Error {
-  constructor({ message, error }) {
-    super(message) // Call the parent class constructor
-    this.message = message
-    this.error = error
-    this.timestamp = new Date() // Add custom properties if needed
-  }
-}
-
 /**
  * Creates an authenticated JWT client for accessing Google APIs.
  *


### PR DESCRIPTION
## What issue is this referencing?

Just a hotfix to fix an error happening on the importer.

Since the `ImportCalendarException` moved my files to `server/utils/calendar.js` I keep on getting the error that it's already imported. I'm not quite sure why this is occurring, but here's a fix I tested locally that works. 

I'm not sure why this is occurring and would love to know why, I thought the autoimport would not run on the server?

## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
