### PR TITLE
Fix broken links in 'Get Involved' section

### DIFF
--- a/components/app/card/Vertical.vue
+++ b/components/app/card/Vertical.vue
@@ -32,7 +32,7 @@ const target = computed(() => {
       :provider="image.startsWith('http') ? undefined : 'imagekit'"
     />
     <div class="relative flex flex-col justify-between h-full p-5">
-      <div class="absolute inset-0 bg-gradient-to-b from-transparent to-gray-400/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg" />
+      <div class="absolute inset-0 bg-gradient-to-b from-transparent to-gray-400/20 opacity-0 group-hover:opacity-100 transition-opacity duration-300 rounded-lg pointer-events-none" />
       <div>
         <h3 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
           {{ name }}


### PR DESCRIPTION
Related to #468

Fix the broken "Get Involved" links by updating the `components/app/card/Vertical.vue` file.

* Add `pointer-events-none` class to the `div` element responsible for the hover behavior.
* Ensure the `div` element no longer prevents clicks from reaching the button.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/devedmonton/DES-Website/pull/472?shareId=1a4273f8-f0e9-4619-8223-ed6bcfc80e89).