### PR TITLE
Added Demo camp to imports for calendar

### DIFF
--- a/server/api/import_events.js
+++ b/server/api/import_events.js
@@ -28,6 +28,7 @@ const ICAL_URLS = [
   'https://www.meetup.com/GDG-Cloud-Edmonton/events/ical/', // GDG cloud
   'http://api.lu.ma/ics/get?entity=calendar&id=cal-N0bfLPnGQ1LC86P', // Leetnight
   'http://api.lu.ma/ics/get?entity=calendar&id=cal-0bDgxCEdnFr1W8O', // Edmonton Data Society
+  'https://api2.luma.com/ics/get?entity=calendar&id=cal-DX3cBt59kMNr4tI', // Democamp.
   'https://www.meetup.com/Edmonton-NET-User-Group/events/ical/', // .NET user group
   'https://www.meetup.com/flutter-edmonton/events/ical/', // flutter edmonton
   'https://www.meetup.com/edmonton-wordpress-meetup-group/events/ical/', // wordpress meetup


### PR DESCRIPTION
## What issue is this referencing?

Adding Demo camp to the devedmonton calendar, nothing else.
<!--
Reference an issue by typing # (outside of this comment) and then searching whatever key words

Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
