### PR TITLE
fix: broken link

### DIFF
--- a/constants/meetups.ts
+++ b/constants/meetups.ts
@@ -3,7 +3,7 @@ export const meetups = [
     name: 'Student Speakers Series',
     description:
       'Meetup where career professionals share their experiences and give advice to students in general. This meetup has a variety of topics, come meet awesome people.',
-    to: 'https:/www.nait.ca/nait/home',
+    to: 'https://www.nait.ca/nait/home',
   },
   {
     name: 'Flutter Edmonton',


### PR DESCRIPTION
## What issue is this referencing?
The link is broken for the student speakers meetup missing a single forward slash

<!--
Reference an issue by typing # (outside of this comment) and then searching whatever key words

Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
