### PR TITLE
Calendar overhaul: full history, pagination, past-event handling, rename-duplicates fix, and source-event links

### DIFF
--- a/components/app/Calendar.vue
+++ b/components/app/Calendar.vue
@@ -49,23 +49,35 @@ const onEventClick = (event: any, e: any) => {
   e.stopPropagation()
 }
 
-// used to display events grouped by month in the list view
-const groupedEvents = computed(() => {
-  return props.group.items.reduce((monthEvents: any, event: any) => {
-    // creating a key to group the events by month in format "Month Year"
-    const monthKey = event.start.toLocaleDateString('en-US', { year: 'numeric', month: 'long' })
+// Group a list of events into a {monthKey: events[]} object, preserving the
+// order events arrive in (callers pre-sort).
+const groupByMonth = (events: any[]) => events.reduce((monthEvents: any, event: any) => {
+  const monthKey = event.start.toLocaleDateString('en-US', { year: 'numeric', month: 'long' })
+  if (!monthEvents[monthKey]) {
+    monthEvents[monthKey] = []
+  }
+  monthEvents[monthKey].push(event)
+  return monthEvents
+}, {})
 
-    // check if there are already events in this month
-    // if not, initialize an empty array for this month
-    if (!monthEvents[monthKey]) {
-      monthEvents[monthKey] = []
-    }
+// Split events into two sections so visitors don't land on years-old events.
+// Upcoming = events still ongoing or in the future, sorted soonest-first.
+// Past     = events that ended before now, sorted most-recent-first.
+const eventSections = computed(() => {
+  const now = new Date()
 
-    // add current in the same month to the array
-    monthEvents[monthKey].push(event)
+  const upcoming = props.group.items
+    .filter((e: any) => e.end >= now)
+    .sort((a: any, b: any) => a.start.getTime() - b.start.getTime())
 
-    return monthEvents
-  }, {})
+  const past = props.group.items
+    .filter((e: any) => e.end < now)
+    .sort((a: any, b: any) => b.start.getTime() - a.start.getTime())
+
+  return [
+    { title: 'Upcoming', months: groupByMonth(upcoming) },
+    { title: 'Past', months: groupByMonth(past) },
+  ]
 })
 </script>
 
@@ -151,14 +163,24 @@ const groupedEvents = computed(() => {
 
     <!-- List View -->
     <div v-if="selectedView === 'list'">
-      <div
-        v-for="(events, month) in groupedEvents"
-        :key="month"
-        class="mb-8"
+      <template
+        v-for="section in eventSections"
+        :key="section.title"
       >
-        <h3 class="text-2xl text-center mb-8 font-bold tracking-tight text-gray-900 dark:text-white">
-          {{ month }}
-        </h3>
+        <h2
+          v-if="Object.keys(section.months).length"
+          class="text-3xl text-center mb-8 font-bold tracking-tight text-gray-900 dark:text-white"
+        >
+          {{ section.title }}
+        </h2>
+        <div
+          v-for="(events, month) in section.months"
+          :key="month"
+          class="mb-8"
+        >
+          <h3 class="text-2xl text-center mb-8 font-bold tracking-tight text-gray-900 dark:text-white">
+            {{ month }}
+          </h3>
         <div class="grid xl:grid-cols-2 gap-4">
           <div
             v-for="(event) in events"
@@ -210,6 +232,7 @@ const groupedEvents = computed(() => {
           </div>
         </div>
       </div>
+      </template>
     </div>
 
     <div class="my-8">

--- a/components/app/Calendar.vue
+++ b/components/app/Calendar.vue
@@ -60,25 +60,60 @@ const groupByMonth = (events: any[]) => events.reduce((monthEvents: any, event: 
   return monthEvents
 }, {})
 
-// Split events into two sections so visitors don't land on years-old events.
-// Upcoming = events still ongoing or in the future, sorted soonest-first.
-// Past     = events that ended before now, sorted most-recent-first.
-const eventSections = computed(() => {
+// Split events into Upcoming (chronological) and Past (reverse chronological).
+const upcomingEvents = computed<any[]>(() => {
   const now = new Date()
-
-  const upcoming = props.group.items
+  return props.group.items
     .filter((e: any) => e.end >= now)
     .sort((a: any, b: any) => a.start.getTime() - b.start.getTime())
+})
 
-  const past = props.group.items
+const pastEvents = computed<any[]>(() => {
+  const now = new Date()
+  return props.group.items
     .filter((e: any) => e.end < now)
     .sort((a: any, b: any) => b.start.getTime() - a.start.getTime())
-
-  return [
-    { title: 'Upcoming', months: groupByMonth(upcoming) },
-    { title: 'Past', months: groupByMonth(past) },
-  ]
 })
+
+// Pagination — both sections paginate independently with their own page state.
+const PAGE_SIZE = 12
+
+const usePagination = (source: ComputedRef<any[]>) => {
+  const page = ref(1)
+  const totalPages = computed(() => Math.max(1, Math.ceil(source.value.length / PAGE_SIZE)))
+  // Clamp the current page if the underlying data shrinks (e.g. on refetch).
+  watch(totalPages, (total) => {
+    if (page.value > total) page.value = total
+  })
+  const items = computed(() => {
+    const start = (page.value - 1) * PAGE_SIZE
+    return source.value.slice(start, start + PAGE_SIZE)
+  })
+  const setPage = (next: number) => {
+    page.value = Math.max(1, Math.min(totalPages.value, next))
+  }
+  return { page, totalPages, items, setPage }
+}
+
+const upcomingPagination = usePagination(upcomingEvents)
+const pastPagination = usePagination(pastEvents)
+
+const eventSections = computed(() => [
+  {
+    title: 'Upcoming',
+    months: groupByMonth(upcomingPagination.items.value),
+    page: upcomingPagination.page.value,
+    totalPages: upcomingPagination.totalPages.value,
+    setPage: upcomingPagination.setPage,
+  },
+  {
+    title: 'Past',
+    months: groupByMonth(pastPagination.items.value),
+    page: pastPagination.page.value,
+    totalPages: pastPagination.totalPages.value,
+    setPage: pastPagination.setPage,
+  },
+])
 </script>
 
 <template>
@@ -232,6 +267,31 @@ const eventSections = computed(() => {
           </div>
         </div>
       </div>
+      <nav
+        v-if="section.totalPages > 1"
+        :aria-label="`${section.title} events pagination`"
+        class="flex items-center justify-center gap-4 mb-8"
+      >
+        <button
+          type="button"
+          class="px-4 py-2 rounded-lg bg-gray-400/20 hover:bg-gray-400/30 disabled:opacity-40 disabled:cursor-not-allowed font-semibold"
+          :disabled="section.page === 1"
+          @click="section.setPage(section.page - 1)"
+        >
+          Previous
+        </button>
+        <span class="text-sm text-gray-600 dark:text-gray-300 tabular-nums">
+          Page {{ section.page }} of {{ section.totalPages }}
+        </span>
+        <button
+          type="button"
+          class="px-4 py-2 rounded-lg bg-gray-400/20 hover:bg-gray-400/30 disabled:opacity-40 disabled:cursor-not-allowed font-semibold"
+          :disabled="section.page === section.totalPages"
+          @click="section.setPage(section.page + 1)"
+        >
+          Next
+        </button>
+      </nav>
       </template>
     </div>
 

--- a/components/app/Calendar.vue
+++ b/components/app/Calendar.vue
@@ -251,14 +251,27 @@ const eventSections = computed(() => [
                   </div>
                 </div>
                 <div
-                  v-if="section.title !== 'Past'"
-                  class="ml-auto"
+                  v-if="event.sourceUrl || section.title !== 'Past'"
+                  class="ml-auto flex flex-col gap-2"
                 >
                   <NuxtLink
+                    v-if="event.sourceUrl"
+                    :to="event.sourceUrl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <AppButton
+                      class="bg-primary text-white hover:text-black w-full"
+                    >
+                      Go to Event
+                    </AppButton>
+                  </NuxtLink>
+                  <NuxtLink
+                    v-if="section.title !== 'Past'"
                     :to="event.eventUrl"
                   >
                     <AppButton
-                      class="bg-primary text-white hover:text-black"
+                      class="bg-primary text-white hover:text-black w-full"
                     >
                       Add to Calendar
                     </AppButton>
@@ -349,12 +362,28 @@ const eventSections = computed(() => [
               <li>Event ends at: {{ selectedEvent.end.formatTime(TIME_FORMAT) }}</li>
             </ul>
           </div>
-          <div v-if="!isSelectedEventPast">
+          <div
+            v-if="selectedEvent.sourceUrl || !isSelectedEventPast"
+            class="flex flex-col gap-2"
+          >
             <NuxtLink
+              v-if="selectedEvent.sourceUrl"
+              :to="selectedEvent.sourceUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <AppButton
+                class="bg-primary text-white hover:text-black w-full"
+              >
+                Go to Event
+              </AppButton>
+            </NuxtLink>
+            <NuxtLink
+              v-if="!isSelectedEventPast"
               :to="selectedEvent.eventUrl"
             >
               <AppButton
-                class="bg-primary text-white hover:text-black"
+                class="bg-primary text-white hover:text-black w-full"
               >
                 Add to Calendar
               </AppButton>

--- a/components/app/Calendar.vue
+++ b/components/app/Calendar.vue
@@ -49,6 +49,13 @@ const onEventClick = (event: any, e: any) => {
   e.stopPropagation()
 }
 
+// True when the currently-selected event has already ended; used to hide the
+// "Add to Calendar" button in the modal for past events.
+const isSelectedEventPast = computed(() => {
+  const end = selectedEvent.value?.end
+  return end instanceof Date && end < new Date()
+})
+
 // Group a list of events into a {monthKey: events[]} object, preserving the
 // order events arrive in (callers pre-sort).
 const groupByMonth = (events: any[]) => events.reduce((monthEvents: any, event: any) => {
@@ -221,6 +228,7 @@ const eventSections = computed(() => [
             v-for="(event) in events"
             :key="event.title"
             class="border-2 border-gray-400/40 rounded mb-4 break-word"
+            :class="{ 'opacity-60': section.title === 'Past' }"
           >
             <div class="p-4 border-b rounded-t border-gray-400/40">
               <h3 class="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-2">
@@ -242,7 +250,10 @@ const eventSections = computed(() => [
                     </p>
                   </div>
                 </div>
-                <div class="ml-auto">
+                <div
+                  v-if="section.title !== 'Past'"
+                  class="ml-auto"
+                >
                   <NuxtLink
                     :to="event.eventUrl"
                   >
@@ -338,7 +349,7 @@ const eventSections = computed(() => [
               <li>Event ends at: {{ selectedEvent.end.formatTime(TIME_FORMAT) }}</li>
             </ul>
           </div>
-          <div>
+          <div v-if="!isSelectedEventPast">
             <NuxtLink
               :to="selectedEvent.eventUrl"
             >
@@ -447,6 +458,24 @@ const eventSections = computed(() => [
 
 .dark .vuecal--month-view .vuecal__cell--out-of-scope .vuecal__event {
   color: rgb(55, 55, 55);
+}
+
+/* Past events: faded so visitors can see at a glance which events have already
+   happened. Hover restores full opacity so the title stays readable. */
+.vuecal__event.past {
+  opacity: 0.5;
+}
+
+.vuecal__event.past:hover {
+  opacity: 1;
+}
+
+.vuecal--month-view .vuecal__event.past {
+  color: #9ca3af;
+}
+
+.dark .vuecal--month-view .vuecal__event.past {
+  color: #6b7280;
 }
 
 .vuecal--month-view .vuecal__event:hover {

--- a/components/app/Calendar.vue
+++ b/components/app/Calendar.vue
@@ -223,99 +223,99 @@ const eventSections = computed(() => [
           <h3 class="text-2xl text-center mb-8 font-bold tracking-tight text-gray-900 dark:text-white">
             {{ month }}
           </h3>
-        <div class="grid xl:grid-cols-2 gap-4">
-          <div
-            v-for="(event) in events"
-            :key="event.title"
-            class="border-2 border-gray-400/40 rounded mb-4 break-word"
-            :class="{ 'opacity-60': section.title === 'Past' }"
-          >
-            <div class="p-4 border-b rounded-t border-gray-400/40">
-              <h3 class="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-2">
-                {{ event.title }}
-              </h3>
+          <div class="grid xl:grid-cols-2 gap-4">
+            <div
+              v-for="(event) in events"
+              :key="event.title"
+              class="border-2 border-gray-400/40 rounded mb-4 break-word"
+              :class="{ 'opacity-60': section.title === 'Past' }"
+            >
+              <div class="p-4 border-b rounded-t border-gray-400/40">
+                <h3 class="text-xl font-bold tracking-tight text-gray-900 dark:text-white mb-2">
+                  {{ event.title }}
+                </h3>
 
-              <div class="p-4 sm:flex justify-between items-center border-b rounded-t border-gray-400/40">
-                <div class="flex flex-col gap-1">
-                  <div class="flex items-center gap-2 sm:gap-4">
-                    <Icon name="formkit:date" />
-                    <p class="text-sm text-gray-500">
-                      {{ DATE_FORMATTER.format(event.start) }}
-                    </p>
+                <div class="p-4 sm:flex justify-between items-center border-b rounded-t border-gray-400/40">
+                  <div class="flex flex-col gap-1">
+                    <div class="flex items-center gap-2 sm:gap-4">
+                      <Icon name="formkit:date" />
+                      <p class="text-sm text-gray-500">
+                        {{ DATE_FORMATTER.format(event.start) }}
+                      </p>
+                    </div>
+                    <div class="flex items-center gap-2">
+                      <Icon name="mingcute:time-line" />
+                      <p class="text-sm text-gray-500">
+                        {{ event.start.formatTime(TIME_FORMAT) }} - {{ event.end.formatTime(TIME_FORMAT) }}
+                      </p>
+                    </div>
                   </div>
-                  <div class="flex items-center gap-2">
-                    <Icon name="mingcute:time-line" />
-                    <p class="text-sm text-gray-500">
-                      {{ event.start.formatTime(TIME_FORMAT) }} - {{ event.end.formatTime(TIME_FORMAT) }}
-                    </p>
+                  <div
+                    v-if="event.sourceUrl || section.title !== 'Past'"
+                    class="ml-auto flex flex-col gap-2"
+                  >
+                    <NuxtLink
+                      v-if="event.sourceUrl"
+                      :to="event.sourceUrl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <AppButton
+                        class="bg-primary text-white hover:text-black w-full"
+                      >
+                        Go to Event
+                      </AppButton>
+                    </NuxtLink>
+                    <NuxtLink
+                      v-if="section.title !== 'Past'"
+                      :to="event.eventUrl"
+                    >
+                      <AppButton
+                        class="bg-primary text-white hover:text-black w-full"
+                      >
+                        Add to Calendar
+                      </AppButton>
+                    </NuxtLink>
                   </div>
-                </div>
-                <div
-                  v-if="event.sourceUrl || section.title !== 'Past'"
-                  class="ml-auto flex flex-col gap-2"
-                >
-                  <NuxtLink
-                    v-if="event.sourceUrl"
-                    :to="event.sourceUrl"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <AppButton
-                      class="bg-primary text-white hover:text-black w-full"
-                    >
-                      Go to Event
-                    </AppButton>
-                  </NuxtLink>
-                  <NuxtLink
-                    v-if="section.title !== 'Past'"
-                    :to="event.eventUrl"
-                  >
-                    <AppButton
-                      class="bg-primary text-white hover:text-black w-full"
-                    >
-                      Add to Calendar
-                    </AppButton>
-                  </NuxtLink>
                 </div>
               </div>
-            </div>
-            <div
-              class="p-4 event-description"
-              :class="{ 'max-w-md': isMobile }"
-            >
-              <p
-                class="content-full"
-                v-html="event.description"
-              />
+              <div
+                class="p-4 event-description"
+                :class="{ 'max-w-md': isMobile }"
+              >
+                <p
+                  class="content-full"
+                  v-html="event.description"
+                />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <nav
-        v-if="section.totalPages > 1"
-        :aria-label="`${section.title} events pagination`"
-        class="flex items-center justify-center gap-4 mb-8"
-      >
-        <button
-          type="button"
-          class="px-4 py-2 rounded-lg bg-gray-400/20 hover:bg-gray-400/30 disabled:opacity-40 disabled:cursor-not-allowed font-semibold"
-          :disabled="section.page === 1"
-          @click="section.setPage(section.page - 1)"
+        <nav
+          v-if="section.totalPages > 1"
+          :aria-label="`${section.title} events pagination`"
+          class="flex items-center justify-center gap-4 mb-8"
         >
-          Previous
-        </button>
-        <span class="text-sm text-gray-600 dark:text-gray-300 tabular-nums">
-          Page {{ section.page }} of {{ section.totalPages }}
-        </span>
-        <button
-          type="button"
-          class="px-4 py-2 rounded-lg bg-gray-400/20 hover:bg-gray-400/30 disabled:opacity-40 disabled:cursor-not-allowed font-semibold"
-          :disabled="section.page === section.totalPages"
-          @click="section.setPage(section.page + 1)"
-        >
-          Next
-        </button>
-      </nav>
+          <button
+            type="button"
+            class="px-4 py-2 rounded-lg bg-gray-400/20 hover:bg-gray-400/30 disabled:opacity-40 disabled:cursor-not-allowed font-semibold"
+            :disabled="section.page === 1"
+            @click="section.setPage(section.page - 1)"
+          >
+            Previous
+          </button>
+          <span class="text-sm text-gray-600 dark:text-gray-300 tabular-nums">
+            Page {{ section.page }} of {{ section.totalPages }}
+          </span>
+          <button
+            type="button"
+            class="px-4 py-2 rounded-lg bg-gray-400/20 hover:bg-gray-400/30 disabled:opacity-40 disabled:cursor-not-allowed font-semibold"
+            :disabled="section.page === section.totalPages"
+            @click="section.setPage(section.page + 1)"
+          >
+            Next
+          </button>
+        </nav>
       </template>
     </div>
 

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -8,6 +8,7 @@ class Event {
   description: string
   class: string
   eventUrl: string
+  sourceUrl: string | undefined
   allDay: boolean
 
   constructor(start: string, end: string, summary: string, organizer: string, content: string, description: string, eventUrl: string) {
@@ -16,6 +17,9 @@ class Event {
     this.title = summary
     this.organizer = organizer
     this.content = content
+    // Parse the source URL out of the raw description before we wrap URLs in
+    // <a> tags — keeps the regex simple.
+    this.sourceUrl = extractSourceUrl(description)
     this.description = description ? renderMarkdown(convertUrlsToLinks(description)) : description
     // vue-cal applies this string as a CSS class on the event element. Mark
     // past events so they can be greyed out in the calendar view.
@@ -33,6 +37,33 @@ const convertUrlsToLinks = (description: string) => {
 
 function renderMarkdown(description: string) {
   return description.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>').replace(/\*(.*?)\*/g, '<em>$1</em>')
+}
+
+// Pulls the canonical event URL out of the description. The cron import (see
+// server/api/import_events.js) appends "Event link: <url>" when the source
+// VEVENT has a URL property. For legacy events that pre-date that marker, fall
+// back to the first meetup.com or lu.ma URL we can find in the body.
+//
+// The character class deliberately stops at HTML/quote/markdown-delimiter
+// chars. Real Meetup and Lu.ma URLs use only [a-zA-Z0-9_\-./?=&%~+#:], so it's
+// safe to bail out at brackets, parens, and asterisks — those are virtually
+// always prose/markdown wrapping the URL (e.g. `(<url>)`, `**<url>**`,
+// `[label](<url>)`, `<a href="<url>">`).
+function extractSourceUrl(description: string): string | undefined {
+  if (!description) return undefined
+  const urlChars = `[^\\s<>"'()\\[\\]{}*]+`
+  const marked = description.match(new RegExp(`Event link:\\s*(https?://${urlChars})`, 'i'))
+  if (marked) return cleanUrl(marked[1])
+  const fallback = description.match(
+    new RegExp(`https?://(?:www\\.|api\\.|api2\\.)?(?:meetup\\.com|lu\\.ma|luma\\.com)/${urlChars}`, 'i'),
+  )
+  return fallback ? cleanUrl(fallback[0]) : undefined
+}
+
+// Strip trailing punctuation that's almost never part of a URL (e.g. a trailing
+// period from a sentence, a comma, or markdown emphasis markers).
+function cleanUrl(url: string): string {
+  return url.replace(/[.,;:!?*_~]+$/, '')
 }
 
 const createEventsList = (events: any) => {

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -17,7 +17,9 @@ class Event {
     this.organizer = organizer
     this.content = content
     this.description = description ? renderMarkdown(convertUrlsToLinks(description)) : description
-    this.class = this.organizer
+    // vue-cal applies this string as a CSS class on the event element. Mark
+    // past events so they can be greyed out in the calendar view.
+    this.class = this.end < new Date() ? 'past' : this.organizer
     this.eventUrl = eventUrl
     this.allDay = false // default
   }

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -46,7 +46,7 @@ const createEventsList = (events: any) => {
 }
 
 let groupCalendar = { name: 'Calendar', items: [] }
-const { pending } = await useLazyFetch('https://devedmonton.com/api/events', {
+const { pending } = await useLazyFetch('/api/events', {
   transform: (data) => {
     groupCalendar = { name: 'Calendar', items: createEventsList((data as any).events) }
 

--- a/server/api/import_events.js
+++ b/server/api/import_events.js
@@ -47,6 +47,11 @@ const fetchICALFromURL = async (url) => {
   return response.text()
 }
 
+// Marker used to embed the source event URL into descriptions in a way that
+// is human-readable in calendar clients and trivially parseable on the website.
+// Keep this string stable — pages/calendar.vue greps for it.
+const EVENT_LINK_PREFIX = 'Event link:'
+
 // converts the ICAL data to google calendar events.
 const parseICALData = (icalContent) => {
   const icalData = ICAL.parse(icalContent) // Parse the ICAL content into jCal format
@@ -57,6 +62,20 @@ const parseICALData = (icalContent) => {
   return events.map((event) => {
     const vevent = new ICAL.Event(event)
 
+    // Some feeds (notably Lu.ma and parts of Meetup) put the canonical event
+    // URL only in the iCal URL property, not in the description body. Pull it
+    // out and append it to the description so subscribers viewing the calendar
+    // in their phone calendar app can click through, and the website can show
+    // a "Go to Event" button without scraping for it.
+    const sourceUrl = vevent.component.getFirstPropertyValue('url')
+    let description = vevent.description || ''
+    if (sourceUrl && !description.includes(sourceUrl)) {
+      const trimmed = description.trim()
+      description = trimmed
+        + (trimmed ? '\n\n' : '')
+        + `${EVENT_LINK_PREFIX} ${sourceUrl}`
+    }
+
     // put this in the format of a google calendar event.
     return {
       // The feed's UID is stable across renames/edits, so we use it as the
@@ -64,7 +83,7 @@ const parseICALData = (icalContent) => {
       // existing Google Calendar event instead of creating a duplicate.
       iCalUID: vevent.uid || undefined,
       summary: vevent.summary || 'No Title',
-      description: vevent.description || '',
+      description,
       location: vevent.location || '',
       start: {
         dateTime: vevent.startDate.toJSDate().toISOString(),

--- a/server/api/import_events.js
+++ b/server/api/import_events.js
@@ -59,6 +59,10 @@ const parseICALData = (icalContent) => {
 
     // put this in the format of a google calendar event.
     return {
+      // The feed's UID is stable across renames/edits, so we use it as the
+      // iCalUID when importing. This is what lets a renamed event update the
+      // existing Google Calendar event instead of creating a duplicate.
+      iCalUID: vevent.uid || undefined,
       summary: vevent.summary || 'No Title',
       description: vevent.description || '',
       location: vevent.location || '',
@@ -131,24 +135,48 @@ const getExistingEvents = async ({ googleCalendarId, serviceAccountCredentials }
 }
 
 /*
-Compares existing gmail events and imported events based on date and title.
-This only returns new events in the calendar.
+Returns the imported events that need to be sent to Google Calendar — either
+because they're brand new, or because they exist but have been renamed in the
+source feed.
+
+Matching strategy (in order):
+  1. iCalUID — the stable feed-side identifier. Survives renames and time
+     changes, so this is the canonical identity check.
+  2. (title + date) — fallback for legacy events that were imported before we
+     started persisting iCalUID. Without this, the first run after this fix
+     would duplicate every existing event.
+
+When iCalUID matches but the title differs, the event is treated as a rename:
+it's passed through so events.import can update the existing record server-side
+rather than skipping it (which would leave the old title in place).
 */
+const titleDateKey = (event) => {
+  const dateOnly = new Date(event.start.dateTime).toISOString().split('T')[0]
+  return `${event.summary.toLowerCase().trim()}|${dateOnly}`
+}
+
 const compareAndGetNewEvents = (existingGmailEvents, importedEvents) => {
-  // check if the importedEvents are in the newEvents
-  const newEvents = importedEvents.filter((importedEvent) => {
-    // check if the event is already in there
-    // check with the title and the start date (I'm assuming there won't be two the same)
-    const importedEventDateOnly = new Date(importedEvent.start.dateTime).toISOString().split('T')[0]
-    return !existingGmailEvents.some((existingEvent) => {
-      const existingDateOnly = new Date(existingEvent.start.dateTime).toISOString().split('T')[0]
-      return (
-        importedEvent.summary.toLowerCase().trim() === existingEvent.summary.toLowerCase().trim() // summary is title for gmail
-        && importedEventDateOnly === existingDateOnly
-      )
-    })
+  // Pre-build lookup indexes so this is O(n+m) instead of O(n*m).
+  const existingByUid = new Map()
+  const existingByTitleDate = new Map()
+  for (const existing of existingGmailEvents) {
+    if (existing.iCalUID) existingByUid.set(existing.iCalUID, existing)
+    existingByTitleDate.set(titleDateKey(existing), existing)
+  }
+
+  return importedEvents.filter((imported) => {
+    // 1. Stable UID match — handles renames going forward.
+    if (imported.iCalUID && existingByUid.has(imported.iCalUID)) {
+      const existing = existingByUid.get(imported.iCalUID)
+      // Same UID + same title -> nothing changed, skip the API call.
+      // Same UID + different title -> source rename; pass through so
+      // events.import can update the existing record.
+      return existing.summary.toLowerCase().trim() !== imported.summary.toLowerCase().trim()
+    }
+    // 2. Legacy fallback — events imported before we tracked iCalUID.
+    if (existingByTitleDate.has(titleDateKey(imported))) return false
+    return true
   })
-  return newEvents
 }
 
 export const importAndProcessExternalEvents = async ({ googleCalendarId, serviceAccountCredentials }) => {

--- a/server/api/import_events.js
+++ b/server/api/import_events.js
@@ -106,6 +106,9 @@ const getAllExternalEvents = async () => {
 }
 
 // gets the existing events from the calendar here.
+// Only future events are needed for dedup, since getAllExternalEvents() filters
+// imported events to future-only as well. Anchoring startDate to today keeps
+// this fast even though getEvents() now returns all events when unfiltered.
 const getExistingEvents = async ({ googleCalendarId, serviceAccountCredentials }) => {
   // try parse the events or throw an error
   try {
@@ -113,6 +116,7 @@ const getExistingEvents = async ({ googleCalendarId, serviceAccountCredentials }
     const events = await getEvents({
       googleCalendarId,
       serviceAccountCredentials,
+      startDate: new Date().toISOString(),
       limitEvents: 100,
     })
     // return the events

--- a/server/serverUtilities/calendar.js
+++ b/server/serverUtilities/calendar.js
@@ -96,14 +96,25 @@ export const getEvents = async ({
   return allItems
 }
 /**
- * Creates new events in the Google Calendar.
+ * Creates or updates events in the Google Calendar.
+ *
+ * Uses `events.import` rather than `events.insert` so the supplied iCalUID is
+ * honored. This gives us two benefits:
+ *  - Events get a stable identifier matching the source feed's UID, so future
+ *    cron runs can dedup correctly.
+ *  - If an event with the same iCalUID already exists, it is updated in
+ *    place — so renames or time changes in the upstream feed propagate
+ *    instead of creating duplicates.
+ *
+ * Events without an iCalUID fall through to events.insert (legacy path).
+ *
  * @async
  * @param {Object} options - The options object.
  * @param {string} options.googleCalendarId - The ID of the Google Calendar should be an email.
  * @param {Object} options.serviceAccountCredentials - The service account credentials for google authentication.
- * @param {Array<Object>} newEvents - The new events to be created.
- * @throws {ImportCalendarException} - Thrown if there is an error while creating events in the Google Calendar.
- * @returns {Promise<void>} - Resolves when all are created.
+ * @param {Array<Object>} options.newEvents - The events to be created or updated.
+ * @throws {ImportCalendarException} - Thrown if there is an error while writing to the calendar.
+ * @returns {Promise<void>} - Resolves when all writes complete.
  */
 export const createAllEvents = async ({
   googleCalendarId,
@@ -117,18 +128,26 @@ export const createAllEvents = async ({
   const calendar = google.calendar({ version: 'v3' })
 
   try {
-    // Map each event to a calendar.events.insert call
-    const insertCalendarPromises = newEvents.map((event) => {
+    const writePromises = newEvents.map((event) => {
+      // events.import requires iCalUID and dedups by it. Use it whenever the
+      // source feed gave us one; fall back to insert for any legacy event
+      // without a UID (e.g. manually created entries).
+      if (event.iCalUID) {
+        return calendar.events.import({
+          auth: client,
+          calendarId: googleCalendarId,
+          resource: event,
+        })
+      }
       return calendar.events.insert({
         auth: client,
         calendarId: googleCalendarId,
         resource: event,
       })
     })
-    // log the created events
-    const responses = await Promise.all(insertCalendarPromises)
+    const responses = await Promise.all(writePromises)
     responses.forEach(() => {
-      console.log(`Event created Successfully!`)
+      console.log(`Event written Successfully!`)
     })
   }
   catch (error) {

--- a/server/serverUtilities/calendar.js
+++ b/server/serverUtilities/calendar.js
@@ -33,12 +33,18 @@ const createAuthClient = (serviceAccountCredentials) => {
 
 /**
  * Retrieves events from Google Calendar.
+ *
+ * When `startDate` is omitted, no `timeMin` filter is applied and ALL events
+ * (past and future) are returned. When `limitEvents` is omitted, pagination is
+ * used to fetch every page until exhausted; otherwise the call is capped to
+ * `limitEvents` results in a single page.
+ *
  * @async
  * @param {Object} options - The options object.
  * @param {string} options.googleCalendarId - The ID of the Google Calendar should be an email.
  * @param {Object} options.serviceAccountCredentials - The service account credentials for google authentication.
- * @param {Date} options.startDate - The start date from which to retrieve events.
- * @param {number} options.limitEvents - The maximum number of events to retrieve.
+ * @param {Date|string} [options.startDate] - Optional lower bound; if omitted, past events are also returned.
+ * @param {number} [options.limitEvents] - Optional cap; if omitted, all events are fetched via pagination.
  * @returns {Promise<Array>} An array of events.
  */
 export const getEvents = async ({
@@ -47,34 +53,47 @@ export const getEvents = async ({
   startDate,
   limitEvents,
 }) => {
-  if (!startDate) {
-    startDate = new Date().toISOString()
-  }
-  else {
-    startDate = new Date(startDate).toISOString()
-  }
+  // Only set timeMin when an explicit startDate is provided. Without it, the
+  // Calendar API returns all events (past + future).
+  const timeMin = startDate ? new Date(startDate).toISOString() : undefined
 
-  if (!limitEvents) {
-    limitEvents = 100
-  }
+  // When the caller doesn't cap results, paginate through every page so the
+  // full history is returned. Google's per-page hard limit is 2500.
+  const shouldPaginate = !limitEvents
+  const pageSize = limitEvents ?? 2500
 
   // get the credentials from the service account
   const client = createAuthClient(serviceAccountCredentials)
 
   // get the calendar api using google
   const calendar = google.calendar({ version: 'v3' })
-  // get the events from the calendar
-  const resposnse = await calendar.events.list({
+
+  const baseParams = {
     auth: client,
     calendarId: googleCalendarId,
-    timeMin: startDate,
-    maxResults: limitEvents,
+    maxResults: pageSize,
     singleEvents: true,
     orderBy: 'startTime',
-  })
+    ...(timeMin ? { timeMin } : {}),
+  }
 
-  // return the events.
-  return resposnse.data.items
+  const allItems = []
+  let pageToken
+
+  do {
+    const response = await calendar.events.list({
+      ...baseParams,
+      ...(pageToken ? { pageToken } : {}),
+    })
+
+    if (response.data.items) {
+      allItems.push(...response.data.items)
+    }
+
+    pageToken = shouldPaginate ? response.data.nextPageToken : undefined
+  } while (pageToken)
+
+  return allItems
 }
 /**
  * Creates new events in the Google Calendar.
@@ -94,8 +113,8 @@ export const createAllEvents = async ({
   // get the credentials from the service account
   const client = createAuthClient(serviceAccountCredentials)
 
-  // // get the calendar api using google
-  const calendar = google.calendar({ version: 'v3' })// get the credentials from the service account
+  // get the calendar api using google
+  const calendar = google.calendar({ version: 'v3' })
 
   try {
     // Map each event to a calendar.events.insert call


### PR DESCRIPTION
Reworks the calendar end-to-end. The public API now returns every past and future event (paginated through the Google Calendar API rather than capped at 100 from today onward), the list view splits into Upcoming/Past with independent pagination per section, past events are visually de-emphasized, the cron-import deduplication is rewritten so source-side renames stop creating duplicates, and the modal/list cards gain a "Go to Event" button that links to the original Meetup/Lu.ma page when available.

This should resolve #420, #467, and #513. 

<!--
Reference an issue by typing # (outside of this comment) and then searching whatever key words

Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [X] yes!

## Does the following command run without warnings or errors?

-   [X] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [X] yes!

## My node version matches the one suggested when running `nvm use`?

-   [X] yes!
