### PR TITLE
Fix calendar duplicate accumulation and "Go to Event" group-URL fallback

### DIFF
--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -40,24 +40,59 @@ function renderMarkdown(description: string) {
 }
 
 // Pulls the canonical event URL out of the description. The cron import (see
-// server/api/import_events.js) appends "Event link: <url>" when the source
+// server/api/import_events.ts) appends "Event link: <url>" when the source
 // VEVENT has a URL property. For legacy events that pre-date that marker, fall
-// back to the first meetup.com or lu.ma URL we can find in the body.
+// back to a meetup.com / lu.ma / elug.ca URL we can find in the body.
+//
+// Preference order: an event-shaped URL (one that points at a specific event,
+// not a group landing page) always wins. Some feeds put the group URL into
+// the iCal URL property; without this preference we would wire "Go to Event"
+// at a group page, which is misleading.
 //
 // The character class deliberately stops at HTML/quote/markdown-delimiter
-// chars. Real Meetup and Lu.ma URLs use only [a-zA-Z0-9_\-./?=&%~+#:], so it's
-// safe to bail out at brackets, parens, and asterisks — those are virtually
-// always prose/markdown wrapping the URL (e.g. `(<url>)`, `**<url>**`,
-// `[label](<url>)`, `<a href="<url>">`).
+// chars. Real Meetup and Lu.ma URLs use only [a-zA-Z0-9_\-./?=&%~+#:], so
+// it is safe to bail out at brackets, parens, and asterisks. Those are
+// virtually always prose/markdown wrapping the URL (e.g. `(<url>)`,
+// `**<url>**`, `[label](<url>)`, `<a href="<url>">`).
 function extractSourceUrl(description: string): string | undefined {
   if (!description) return undefined
   const urlChars = `[^\\s<>"'()\\[\\]{}*]+`
+
+  // Pass 1: explicit "Event link:" marker, validated as an event URL. The
+  // importer sets this from the iCal URL property; rejecting non-event-shaped
+  // values defends against feeds that put a group URL there by mistake.
   const marked = description.match(new RegExp(`Event link:\\s*(https?://${urlChars})`, 'i'))
-  if (marked) return cleanUrl(marked[1])
-  const fallback = description.match(
-    new RegExp(`https?://(?:www\\.|api\\.|api2\\.)?(?:meetup\\.com|lu\\.ma|luma\\.com)/${urlChars}`, 'i'),
+  if (marked && looksLikeEventUrl(marked[1])) return cleanUrl(marked[1])
+
+  // Pass 2: scan the body for any event-shaped URL on a known platform.
+  // Catches legacy events that pre-date the "Event link:" marker.
+  const eventShaped = description.match(
+    new RegExp(
+      `https?://(?:www\\.|api\\.|api2\\.)?(?:meetup\\.com/[^/]+/events/\\d+|lu\\.ma/[a-z0-9-]+|luma\\.com/event/${urlChars}|elug\\.ca/(?:events?|meetings?)/${urlChars})/?`,
+      'i',
+    ),
   )
-  return fallback ? cleanUrl(fallback[0]) : undefined
+  if (eventShaped) return cleanUrl(eventShaped[0])
+
+  // Pass 3: honor the "Event link:" marker even if it does not look
+  // event-shaped. The importer set it for a reason, so this is better than
+  // returning nothing. If the only URL we have is a group page, the next
+  // pass will surface that as a last resort.
+  if (marked) return cleanUrl(marked[1])
+
+  return undefined
+}
+
+// True when the URL points at a specific event rather than a group landing
+// page. The meetup.com check requires a /events/<numeric-id> segment; Lu.ma
+// event URLs sit at the domain root (lu.ma/<slug>); luma.com uses /event/;
+// elug.ca uses /events/ or /meetings/.
+function looksLikeEventUrl(url: string): boolean {
+  if (/meetup\.com\/[^/]+\/events\/\d+/i.test(url)) return true
+  if (/(?:www\.)?lu\.ma\/[a-z0-9-]+/i.test(url)) return true
+  if (/luma\.com\/event\//i.test(url)) return true
+  if (/elug\.ca\/(?:events?|meetings?)\//i.test(url)) return true
+  return false
 }
 
 // Strip trailing punctuation that's almost never part of a URL (e.g. a trailing

--- a/server/api/import_events.ts
+++ b/server/api/import_events.ts
@@ -157,7 +157,6 @@ const getExistingEvents = async ({ googleCalendarId, serviceAccountCredentials }
       googleCalendarId,
       serviceAccountCredentials,
       startDate: new Date().toISOString(),
-      limitEvents: 100,
     })
     // return the events
     return events


### PR DESCRIPTION
## What issue is this referencing?

Two narrowly-scoped fixes to the calendar import + render pipeline, both responding to a single live incident: a `.NET User Group` placeholder event had accumulated 934 duplicate copies on our public Google Calendar over seven months, and the "Go to Event" button was rendering group landing pages for some legacy events instead of event pages.

### `server/api/import_events.ts`

Removed the `limitEvents: 100` cap on `getExistingEvents`. With the cap in place, any future event sitting past the first hundred entries in the calendar was invisible to the dedup check, which is exactly how the 2031 placeholder kept getting re-imported. `getEvents` paginates fully when `limitEvents` is omitted, so this restores correct dedup behavior across the entire future window.

```diff
     const events = await getEvents({
       googleCalendarId,
       serviceAccountCredentials,
       startDate: new Date().toISOString(),
-      limitEvents: 100,
     })
```

The `startDate: new Date().toISOString()` anchor remains, so we only paginate forward from today rather than walking the entire calendar history.

### `pages/calendar.vue`

Rewrote `extractSourceUrl` with explicit preference for event-shaped URLs over group landing pages, and added a `looksLikeEventUrl` helper that encodes the per-platform rules. The previous logic accepted the first URL it found on the domain allowlist, which meant a description containing `https://www.meetup.com/<group-slug>/` (the group page) anywhere in its body would render that as the "Go to Event" target even when an actual event URL also existed.

New preference order:

1. `Event link:` marker (added by the importer from the iCal `URL` property), but only if the URL looks like a specific event.
2. Body scan for any event-shaped URL on a known platform (Meetup `/events/<id>`, Lu.ma slug, luma.com `/event/`, elug.ca `/events/` or `/meetings/`).
3. `Event link:` marker as last-resort fallback, even when not event-shaped, so the importer's explicit assertion is still honored.
4. Otherwise no button renders. This is intentional. The label promises an event page, so rendering nothing is better than rendering a group page.

Also added `elug.ca` to the body-scan domain allowlist while in the same function. Edmonton Linux User Group events live on that domain rather than Meetup or Lu.ma.

## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
