### PR TITLE
Change title from 'companies' to 'Companies'

### DIFF
--- a/pages/companies.vue
+++ b/pages/companies.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const group = { name: 'Edmonton Companies', items: companies.sort((a, b) => a.name.localeCompare(b.name)) }
 
-const title = 'companies'
+const title = 'Companies'
 const description = 'Lists of all the companies who are part of the Dev Edmonton community.'
 
 useServerSeoMeta({


### PR DESCRIPTION
## What issue is this referencing?

There currently is no issue for this edit, it was just a minor inconsistency that I noticed when browsing the website. All the other pages tab titles are capitalized except for the one for "companies".

<!--
Reference an issue by typing # (outside of this comment) and then searching whatever key words

Say something like "this pr fixes #123" because github uses keywords like "fixes" to auto close the issues when the pr is merged. See more info [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
## Do these code changes work locally and have you tested that they fix the issue yourself?

-   [x] yes!

## Does the following command run without warnings or errors?

-   [x] yes! `npm run pr-checks`

## Have you taken a look at our [contributing guidelines](https://github.com/devedmonton/DES-Website/blob/main/.github/CONTRIBUTING.md)?

-   [x] yes!

## My node version matches the one suggested when running `nvm use`?

-   [x] yes!
